### PR TITLE
Make it possible to detect new redis-server binary (when using multiple instances)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,16 @@
     - redis
     - redis-configure
 
+- name: configure | version | get
+  command: redis-server --version
+  register: redis_binary_version
+  changed_when: false
+  tags:
+    - configuration
+    - redis
+    - redis-configure
+    - redis-configure-version-get
+
 - include: configure-initd.yml
   when: ansible_distribution_version | version_compare('15.04', '<')
   tags:

--- a/templates/etc/init.d/redis-server.j2
+++ b/templates/etc/init.d/redis-server.j2
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# {{ ansible_managed }}
+# {{ ansible_managed }}, {{ redis_binary_version.stdout }}
 #
 ### BEGIN INIT INFO
 # Provides:		{{ redis_instance_service }}

--- a/templates/lib/systemd/system/redis-server.service.j2
+++ b/templates/lib/systemd/system/redis-server.service.j2
@@ -1,4 +1,4 @@
-; {{ ansible_managed }}
+; {{ ansible_managed }}, {{ redis_binary_version.stdout }}
 
 [Unit]
 Description={{ redis_instance_service }} - Persistent key-value db


### PR DESCRIPTION
To be able to restart (all) instances on updates / recompilation, instead of only the first one